### PR TITLE
Fix: Cancel Button

### DIFF
--- a/controllers/FileExplorerController.py
+++ b/controllers/FileExplorerController.py
@@ -105,6 +105,8 @@ class FileExplorerController:
         # If this is the case, we close the file explorer
         if event.ui_object_id == '#file_dialog.#close_button':
             self._close_file_explorer()
+        if event.ui_object_id == '#file_dialog.#cancel_button':
+            self._close_file_explorer()
 
     def _handle_select_file(self, event) -> None:
         '''

--- a/controllers/FileExplorerController.py
+++ b/controllers/FileExplorerController.py
@@ -103,9 +103,7 @@ class FileExplorerController:
         This method checks if the button clicked is the close button.
         '''
         # If this is the case, we close the file explorer
-        if event.ui_object_id == '#file_dialog.#close_button':
-            self._close_file_explorer()
-        if event.ui_object_id == '#file_dialog.#cancel_button':
+        if event.ui_object_id == '#file_dialog.#close_button' or event.ui_object_id == '#file_dialog.#cancel_button':
             self._close_file_explorer()
 
     def _handle_select_file(self, event) -> None:


### PR DESCRIPTION
The cancel button is now working.
Previously, the program was stuck while clicking on "cancel" because it wasn't calling the _close_file_explorer() function.