### PR TITLE
Respect image ratio

### DIFF
--- a/controllers/GraphController.py
+++ b/controllers/GraphController.py
@@ -198,10 +198,6 @@ class GraphController:
         # Check if the image exists in the folder
         if self._image_service.check_if_image_exists(image_path):
             background_image = pygame.image.load(image_path)
-            background_image = pygame.transform.scale(
-                background_image,
-                (GRAPH_WINDOW_WIDTH, GRAPH_WINDOW_HEIGHT)
-            )
             self._graph_view.set_background_image(background_image)
         else:
             print(f"Image {image_name} not found or could not be copied.")
@@ -278,9 +274,15 @@ class GraphController:
         self._create_link(pos)
         self._select_node(node)
 
-    def _is_within_bounds(self, pos: tuple[int, int]) -> bool:
-        return (NODE_RADIUS < pos[0] < GRAPH_WINDOW_WIDTH - NODE_RADIUS and
-                NODE_RADIUS < pos[1] < GRAPH_WINDOW_HEIGHT - NODE_RADIUS)
+    def is_within_bounds(self, pos) -> bool:
+        bounds = self._graph_view.get_image_bounds()
+        margin_left = bounds["margin_left"]
+        margin_top = bounds["margin_top"]
+        scaled_width = bounds["scaled_width"]
+        scaled_height = bounds["scaled_height"]
+
+        return (margin_left < pos[0] < margin_left + scaled_width and
+                margin_top < pos[1] < margin_top + scaled_height)
 
     def update(self) -> None:
         """

--- a/controllers/GraphController.py
+++ b/controllers/GraphController.py
@@ -3,8 +3,7 @@ import re
 
 import pygame
 
-from constants.Config import GRAPH_WINDOW_WIDTH, GRAPH_WINDOW_HEIGHT, NODE_RADIUS
-from controllers.NodeController import NodeController
+from constants.Config import GRAPH_WINDOW_WIDTH, GRAPH_WINDOW_HEIGHT
 from controllers.EdgeController import EdgeController
 from controllers.NodeController import NodeController
 from models.Agent import Agent
@@ -12,10 +11,10 @@ from models.Graph import Graph
 from models.GraphData import GraphData
 from models.GraphDataComplements import GraphDataComplements
 from models.Node import Node
-from views.GraphView import GraphView
-
 from services import IImageService
 from services.ICSVService import ICSVService
+from views.GraphView import GraphView
+
 
 class GraphController:
     """
@@ -275,6 +274,15 @@ class GraphController:
         self._select_node(node)
 
     def _is_within_bounds(self, pos) -> bool:
+        """
+        Checks if the given position is within the bounds of the graph view.
+
+        Args:
+            pos (tuple[int, int]): The position to check.
+
+        Returns:
+            bool: True if the position is within bounds, otherwise False.
+        """
         bounds = self._graph_view.get_image_bounds()
         margin_left = bounds["margin_left"]
         margin_top = bounds["margin_top"]

--- a/controllers/GraphController.py
+++ b/controllers/GraphController.py
@@ -274,7 +274,7 @@ class GraphController:
         self._create_link(pos)
         self._select_node(node)
 
-    def is_within_bounds(self, pos) -> bool:
+    def _is_within_bounds(self, pos) -> bool:
         bounds = self._graph_view.get_image_bounds()
         margin_left = bounds["margin_left"]
         margin_top = bounds["margin_top"]

--- a/tests/test_GraphController.py
+++ b/tests/test_GraphController.py
@@ -37,7 +37,7 @@ class TestGraphController(unittest.TestCase):
         self.graph_controller.graph.edges = []
 
         # Configure mocked methods
-        self.graph_controller.graph_view.get_image_bounds.return_value = {
+        self.graph_controller._graph_view.get_image_bounds.return_value = {
             "margin_left": 0,
             "margin_top": 0,
             "scaled_width": GRAPH_WINDOW_WIDTH,

--- a/tests/test_GraphController.py
+++ b/tests/test_GraphController.py
@@ -36,6 +36,13 @@ class TestGraphController(unittest.TestCase):
         self.graph_controller.graph.nodes = []
         self.graph_controller.graph.edges = []
 
+        # Configure mocked methods
+        self.graph_controller.graph_view.get_image_bounds.return_value = {
+            "margin_left": 0,
+            "margin_top": 0,
+            "scaled_width": GRAPH_WINDOW_WIDTH,
+            "scaled_height": GRAPH_WINDOW_HEIGHT
+        }
         self.graph_controller._load_graph = MagicMock()
 
     def tearDown(self):

--- a/views/GraphView.py
+++ b/views/GraphView.py
@@ -113,8 +113,10 @@ class GraphView:
         if self._background_image is None:
             self._screen.fill(Colors.WHITE.value)
         else:
-            self._screen.blit(self._background_image, (self._margin_left,
-                                                       self._margin_top))
+            self._screen.blit(
+                self._background_image,
+                (self._margin_left, self._margin_top)
+            )
 
         # Draw nodes
         for node in graph.nodes:

--- a/views/GraphView.py
+++ b/views/GraphView.py
@@ -3,13 +3,14 @@ from typing import Optional
 import pygame
 
 from constants.Colors import Colors
-from constants.Config import NODE_RADIUS
+from constants.Config import NODE_RADIUS, GRAPH_WINDOW_WIDTH, GRAPH_WINDOW_HEIGHT
 from models.Agent import Agent
 from models.Graph import Graph
 from models.Node import Node
 from views.popup.PopupView import PopupView
 from views.popup.InfoPopupView import InfoPopupView
 from views.popup.ErrorPopupView import ErrorPopupView
+
 
 class GraphView:
     """
@@ -24,25 +25,49 @@ class GraphView:
         _background_image (Optional[pygame.Surface]): The background
             image for the graph view, or None if no background is set.
     """
-    def __init__(self, screen: pygame.Surface) -> None:
+    def __init__(self, screen) -> None:
         self._screen = screen
         self._background_image = None
-        self._popup = None
+        self._scaled_width = None
+        self._scaled_height = None
+        self._margin_left = 0
+        self._margin_top = 0
 
-    def set_background_image(
-        self,
-        background_image: Optional[pygame.Surface]
-    ) -> None:
-        """
-        Sets the background image for the view.
-
-        If None is passed, the background image will be cleared.
-
-        Args:
-            background_image (Optional[pygame.Surface]): The background
-                image for the graph view, or None to clear it.
-        """
+    def set_background_image(self, background_image):
+        """Set the background image for the view."""
+        # Store the image in an instance variable
         self._background_image = background_image
+
+        # Get the original dimensions of the image
+        original_width, original_height = self._background_image.get_width(), self._background_image.get_height()
+        window_ratio = GRAPH_WINDOW_WIDTH / GRAPH_WINDOW_HEIGHT
+        image_ratio = original_width / original_height
+
+        # Adjust the image to fit the window size
+        if image_ratio > window_ratio:
+            self._scaled_width = GRAPH_WINDOW_WIDTH
+            self._scaled_height = int(GRAPH_WINDOW_WIDTH / image_ratio)
+            self._margin_top = (GRAPH_WINDOW_HEIGHT - self._scaled_height) // 2
+            self._margin_left = 0
+        elif image_ratio < window_ratio:
+            self._scaled_height = GRAPH_WINDOW_HEIGHT
+            self._scaled_width = int(GRAPH_WINDOW_HEIGHT * image_ratio)
+            self._margin_left = (GRAPH_WINDOW_WIDTH - self._scaled_width) // 2
+            self._margin_top = 0
+
+        # Draw margins and render the image
+        margin_color = Colors.BLACK.value
+        self._screen.fill(margin_color)
+        # Scale the image and store it as the final background
+        self._background_image = pygame.transform.scale(self._background_image, (self._scaled_width, self._scaled_height))
+
+    def get_image_bounds(self):
+        return {
+            "scaled_width": self._scaled_width,
+            "scaled_height": self._scaled_height,
+            "margin_left": self._margin_left,
+            "margin_top": self._margin_top
+        }
 
     def draw_graph(
         self,
@@ -68,8 +93,9 @@ class GraphView:
         if self._background_image is None:
             self._screen.fill(Colors.WHITE.value)
         else:
-            self._screen.blit(self._background_image, (0, 0))
+            self._screen.blit(self._background_image, (self._margin_left, self._margin_top))
 
+        # Draw nodes
         for node in graph.nodes:
             color = self._get_node_color(node, selected_node, dragging_node)
             pygame.draw.circle(

--- a/views/GraphView.py
+++ b/views/GraphView.py
@@ -25,13 +25,14 @@ class GraphView:
         _background_image (Optional[pygame.Surface]): The background
             image for the graph view, or None if no background is set.
     """
-    def __init__(self, screen) -> None:
+    def __init__(self, screen: pygame.Surface) -> None:
         self._screen = screen
         self._background_image = None
         self._scaled_width = None
         self._scaled_height = None
         self._margin_left = 0
         self._margin_top = 0
+        self._popup = None
 
     def set_background_image(self, background_image):
         """Set the background image for the view."""

--- a/views/GraphView.py
+++ b/views/GraphView.py
@@ -3,7 +3,8 @@ from typing import Optional
 import pygame
 
 from constants.Colors import Colors
-from constants.Config import NODE_RADIUS, GRAPH_WINDOW_WIDTH, GRAPH_WINDOW_HEIGHT
+from constants.Config import NODE_RADIUS, GRAPH_WINDOW_WIDTH, \
+    GRAPH_WINDOW_HEIGHT
 from models.Agent import Agent
 from models.Graph import Graph
 from models.Node import Node
@@ -35,12 +36,20 @@ class GraphView:
         self._popup = None
 
     def set_background_image(self, background_image):
-        """Set the background image for the view."""
+        """
+        Set the background image for the view, adjusting its size to
+        fit the window and centering it with margins.
+
+        Args:
+            background_image (pygame.Surface): The image to be set as
+                the background.
+        """
         # Store the image in an instance variable
         self._background_image = background_image
 
         # Get the original dimensions of the image
-        original_width, original_height = self._background_image.get_width(), self._background_image.get_height()
+        original_width, original_height = self._background_image.get_width(), \
+                                          self._background_image.get_height()
         window_ratio = GRAPH_WINDOW_WIDTH / GRAPH_WINDOW_HEIGHT
         image_ratio = original_width / original_height
 
@@ -60,9 +69,19 @@ class GraphView:
         margin_color = Colors.BLACK.value
         self._screen.fill(margin_color)
         # Scale the image and store it as the final background
-        self._background_image = pygame.transform.scale(self._background_image, (self._scaled_width, self._scaled_height))
+        self._background_image = pygame.transform.scale(self._background_image,
+                                                        (self._scaled_width,
+                                                         self._scaled_height))
 
     def get_image_bounds(self):
+        """
+        Retrieve the dimensions and margins of the scaled image.
+
+        Returns:
+            dict: A dictionary containing the keys 'scaled_width',
+            'scaled_height', 'margin_left', and 'margin_top', each
+            with their respective values as integers.
+        """
         return {
             "scaled_width": self._scaled_width,
             "scaled_height": self._scaled_height,
@@ -94,7 +113,8 @@ class GraphView:
         if self._background_image is None:
             self._screen.fill(Colors.WHITE.value)
         else:
-            self._screen.blit(self._background_image, (self._margin_left, self._margin_top))
+            self._screen.blit(self._background_image, (self._margin_left,
+                                                       self._margin_top))
 
         # Draw nodes
         for node in graph.nodes:
@@ -192,21 +212,30 @@ class GraphView:
     
     def show_error_popup(self, message: str) -> None:
         """
-        Shows an Error Popup
+        Displays an error popup with the specified message.
+
+        Args:
+            message (str): The error message to be displayed.
         """
         popup_view = ErrorPopupView(self._screen, message)
         self._show_pop_up_type(popup_view)
 
     def show_info_popup(self, message: str) -> None:
         """
-        Shows an Info Popup
+        Displays an informational popup with the specified message.
+
+        Args:
+            message (str): The info message to be displayed.
         """
         popup_view = InfoPopupView(self._screen, message)
         self._show_pop_up_type(popup_view)
     
     def show_popup(self, message: str) -> None:
         """
-        Shows a Popup
+        Displays a generic popup with the specified message.
+
+        Args:
+            message (str): The message to be displayed in the popup.
         """
         popup_view = PopupView(self._screen, message)
         self._show_pop_up_type(popup_view)

--- a/views/GraphView.py
+++ b/views/GraphView.py
@@ -35,7 +35,10 @@ class GraphView:
         self._margin_top = 0
         self._popup = None
 
-    def set_background_image(self, background_image):
+    def set_background_image(
+        self,
+        background_image: pygame.Surface
+    ) -> None:
         """
         Set the background image for the view, adjusting its size to
         fit the window and centering it with margins.
@@ -73,7 +76,7 @@ class GraphView:
                                                         (self._scaled_width,
                                                          self._scaled_height))
 
-    def get_image_bounds(self):
+    def get_image_bounds(self) -> dict[str, int]:
         """
         Retrieve the dimensions and margins of the scaled image.
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling and rendering of background images in the `GraphView` class and to update related methods in the `GraphController` class. The changes ensure that background images are properly scaled and centered, and that node positions are correctly checked within the bounds of the scaled image.

### Changes to background image handling:

* [`views/GraphView.py`](diffhunk://#diff-46e402bdb183c1ed754a100ccce519ec0ef8aac3e485927de08ad32115fa03efL4-R68): Modified the `set_background_image` method to scale and center the background image based on the window size and image aspect ratio, and added a method `get_image_bounds` to retrieve the calculated bounds.
* [`controllers/GraphController.py`](diffhunk://#diff-18e7c156ebebb44414ddc7a6d8c45ec13dad3b9f7822b497a5c89d38eea8ad42L95): Updated the `load_background_image` method to remove the scaling operation, as it is now handled in `GraphView`.

### Changes to node position checking:

* [`controllers/GraphController.py`](diffhunk://#diff-18e7c156ebebb44414ddc7a6d8c45ec13dad3b9f7822b497a5c89d38eea8ad42L137-R143): Modified the `is_within_bounds` method to use the image bounds from `GraphView` for checking node positions.