### PR TITLE
Fix: Textbox number deletion

### DIFF
--- a/controllers/text_boxes/AlgorithmParametersController.py
+++ b/controllers/text_boxes/AlgorithmParametersController.py
@@ -1,4 +1,7 @@
+import pygame
+
 from controllers.text_boxes.BaseTextBoxController import BaseTextBoxController
+from models.TextBox import TextBox
 from models.algorithms.IAlgorithmModel import IAlgorithmModel
 from views.ParametersView import ParametersView
 from views.text_boxes.AlgorithmParametersView import AlgorithmParametersView
@@ -66,3 +69,22 @@ class AlgorithmParametersController(BaseTextBoxController):
             )
             
             self.add_text_box(parameter, text_box_view)
+
+    def handle_keyboard(self, event: pygame.event.Event, model: TextBox):
+        """
+        Handles keyboard input when the text box is active for
+        algorithm parameters.
+
+        This override allows handling of decimal points.
+        """
+        # If it is the first time the text box is being written to and
+        # the pressed key is valid (a digit), reset the default text
+        if model.first_input and event.unicode.isdigit():
+            model.reset()
+
+        # If the backspace key is pressed
+        if event.key == pygame.K_BACKSPACE:
+            model.handle_backspace()
+        # Otherwise, handle digits and allow points
+        elif event.unicode.isdigit() or event.unicode == '.':
+            model.add_character(event.unicode)

--- a/controllers/text_boxes/BaseTextBoxController.py
+++ b/controllers/text_boxes/BaseTextBoxController.py
@@ -106,7 +106,7 @@ class BaseTextBoxController:
         if event.key == pygame.K_BACKSPACE:
             model.handle_backspace()
         # If it's not the backspace key, it must be a digit key
-        elif event.unicode.isdigit() or event.unicode == '.':
+        elif event.unicode.isdigit():
             model.add_character(event.unicode)
 
     def is_text_box_text_completed(self, model: TextBox) -> bool:

--- a/controllers/text_boxes/BaseTextBoxController.py
+++ b/controllers/text_boxes/BaseTextBoxController.py
@@ -117,7 +117,7 @@ class BaseTextBoxController:
         Returns:
             bool: True if completed, False otherwise.
         """
-        return model.default_text != model.text_content
+        return model.default_text != model.text_content or not model.first_input
 
     def is_text_box_hovered(self, event, text_box_view) -> bool:
         """

--- a/models/TextBox.py
+++ b/models/TextBox.py
@@ -99,11 +99,8 @@ class TextBox:
             bool: Whether the text content is filled and differs from
                 the default text.
         """
-        return (
-            self._default_text != self._text_content
-            and not self.empty
-        )
-    
+        return not self.empty and not self._first_input
+
     def reset(self) -> None:
         """
         Resets the text box to its default text.
@@ -129,10 +126,17 @@ class TextBox:
         Handles the backspace functionality and resets the text if it
         becomes empty.
         """
-        if self._default_text != self._text_content:
+         # Do nothing if the content is already the default text
+        if self._text_content == self._default_text and self._first_input:
+            return
+
+        # Remove the last character if there is any text
+        if not self.empty:
             self.remove_character()
-            if self.empty:
-                self.reset()
+
+        # If the text becomes empty, reset to default text
+        if self.empty:
+            self.reset()
 
     def remove_character(self) -> None:
         """


### PR DESCRIPTION
The user is now able to delete a number corresponding to its default value in the textboxes.
It is no longer possible to add a decimal to the number of agents.

Closes #103