### PR TITLE
fix: bug save and clearing when no nodes

### DIFF
--- a/controllers/FileExplorerController.py
+++ b/controllers/FileExplorerController.py
@@ -145,6 +145,8 @@ class FileExplorerController:
             self._graph_controller.raise_error_message(str(e))
         except Info as e:
             self._graph_controller.raise_info(str(e))
+            if self._on_file_imported:
+                self._on_file_imported()
         else:
             self._graph_controller.raise_message(success_message)
             if self._on_file_imported:  # Call the callback if it's defined


### PR DESCRIPTION
This pull request includes an enhancement to the `FileExplorerController` to ensure a callback is executed when a file is imported, regardless of whether an info message is raised.

* [`controllers/FileExplorerController.py`](diffhunk://#diff-d2a29fde4f33487695cf4e5e4f4966ef047deb8f6849cdaf6e8bbe7c17e35dafR148-R149): Added a call to `_on_file_imported` within the `except Info` block to ensure the callback is executed when an info message is raised.